### PR TITLE
Refactor fetchers structure

### DIFF
--- a/src/core.tsx
+++ b/src/core.tsx
@@ -1,15 +1,12 @@
 import type { ReactNode } from "react"
 import type { Address, Loader, NftMetadata } from "./types"
 
-import React, { createContext, useContext } from "react"
+import React, { createContext, useCallback, useContext } from "react"
+import { useLoad } from "./utils"
 
 export type Fetcher<Config> = {
   config: Config
-  useNft: (
-    fetcher: Fetcher<Config>,
-    contractAddress: Address,
-    tokenId: string
-  ) => Loader<NftMetadata>
+  fetchNft: (contractAddress: Address, tokenId: string) => Promise<NftMetadata>
 }
 
 export type NftProviderType = {
@@ -35,7 +32,14 @@ function useNft(
   if (context === null) {
     throw new Error("Please wrap your app with <NftProvider />")
   }
-  return context.fetcher.useNft(context.fetcher, contractAddress, tokenId)
+  const { fetcher } = context
+  return useLoad<NftMetadata>(
+    useCallback(() => fetcher.fetchNft(contractAddress, tokenId), [
+      contractAddress,
+      fetcher,
+      tokenId,
+    ])
+  )
 }
 
 export { useNft, NftProvider }

--- a/src/fetchers/ethers/index.tsx
+++ b/src/fetchers/ethers/index.tsx
@@ -1,20 +1,22 @@
-import type { Address, Loader, NftMetadata } from "../../types"
+import type { Address, NftMetadata } from "../../types"
 import type { EthersFetcher, EthersFetcherOptions } from "./types"
 
-import { useCallback } from "react"
-import { useLoad } from "../../utils"
 import { cryptoPunksMetadata, isCryptoPunks } from "./cryptopunks"
 import { cryptoKittiesMetadata, isCryptoKitties } from "./cryptokitties"
 import { moonCatsMetadata, isMoonCats } from "./mooncats"
 import { standardNftMetadata, isStandardNft } from "./standard-nft"
 
-export function useNft(
-  fetcher: EthersFetcher,
-  contractAddress: Address,
-  tokenId: string
-): Loader<NftMetadata> {
-  return useLoad<NftMetadata>(
-    useCallback(async () => {
+export default function ethersFetcher({
+  ethers,
+  provider,
+}: EthersFetcherOptions): EthersFetcher {
+  const config = { ethers, provider }
+  return {
+    config,
+    async fetchNft(
+      contractAddress: Address,
+      tokenId: string
+    ): Promise<NftMetadata> {
       if (isCryptoPunks(contractAddress)) {
         return cryptoPunksMetadata(tokenId)
       }
@@ -24,24 +26,14 @@ export function useNft(
       }
 
       if (isMoonCats(contractAddress)) {
-        return moonCatsMetadata(tokenId, fetcher.config)
+        return moonCatsMetadata(tokenId, config)
       }
 
       if (isStandardNft(contractAddress)) {
-        return standardNftMetadata(tokenId, contractAddress, fetcher.config)
+        return standardNftMetadata(tokenId, contractAddress, config)
       }
 
       throw new Error("Invalid contract address or token ID provided")
-    }, [contractAddress, tokenId, fetcher])
-  )
-}
-
-export function ethersFetcher({
-  ethers,
-  provider,
-}: EthersFetcherOptions): EthersFetcher {
-  return {
-    config: { ethers, provider },
-    useNft,
+    },
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
 export { NftProvider, useNft } from "./core"
 export { parseNftUrl } from "./utils"
-export { ethersFetcher } from "./fetchers/ethers"
+export { default as ethersFetcher } from "./fetchers/ethers"
 export type { Loader, NftMetadata } from "./types"


### PR DESCRIPTION
This is in preparation of other fetchers being added. Fetchers now
contain simple functions returning promises or throwing, and don’t
require to use React Hooks anymore. This is mostly to make their
implementation more concise.