### PR TITLE
Types fixes

### DIFF
--- a/src/core.tsx
+++ b/src/core.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react"
+import type { FC, ReactNode } from "react"
 import type {
   Address,
   Fetcher,
@@ -69,16 +69,12 @@ const NftContext = createContext<{
   fetcher?: Fetcher<unknown> | null
 } | null>(null)
 
-function NftProvider({
-  children,
-  fetcher,
-}: {
+const NftProvider: FC<{
   children: ReactNode
   fetcher?: Fetcher<unknown> | FetcherDeclaration | null
-}): JSX.Element {
-  const normalizedFetcher = normalizeFetcher(fetcher)
+}> = function NftProvider({ children, fetcher }) {
   return (
-    <NftContext.Provider value={{ fetcher: normalizedFetcher }}>
+    <NftContext.Provider value={{ fetcher: normalizeFetcher(fetcher) }}>
       {children}
     </NftContext.Provider>
   )

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -221,8 +221,8 @@ export function promiseAny<T>(promises: Promise<T>[]): Promise<T> {
     Promise.all([...promises].map(reversePromise))
   ) as Promise<T>
 }
-export function reversePromise(promise: Promise<unknown>) {
-  return new Promise((resolve, reject) =>
+export function reversePromise(promise: Promise<unknown>): Promise<unknown> {
+  return new Promise((resolve, reject) => {
     Promise.resolve(promise).then(reject, resolve)
-  )
+  })
 }


### PR DESCRIPTION
- `reversePromise()`: add return type.
- `NftProvider` return type: move to `React.FC`.