### PR TITLE
Add new field: nft.owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ function Nft() {
       <h1>{nft.name}</h1>
       <img src={nft.image} alt="" />
       <p>{nft.description}</p>
+      <p>Owner: {nft.owner}</p>
     </section>
   )
 }
@@ -121,6 +122,9 @@ result.nft.description
 
 // image / media URL of the NFT (or empty string)
 result.nft.image
+
+// current owner of the NFT (or empty string)
+result.nft.owner
 ```
 
 As TypeScript type:
@@ -132,9 +136,10 @@ type NftResult = {
   reload: () => void
   error?: Error
   nft?: {
-    name: string
     description: string
     image: string
+    name: string
+    owner: string
   }
 }
 ```

--- a/examples/ethereum/src/Nft.tsx
+++ b/examples/ethereum/src/Nft.tsx
@@ -131,9 +131,9 @@ function NftDetails({ nft }: { nft?: NftMetadata }) {
     return null
   }
 
+  const { image } = nft
   const name = nft.name || "Untitled"
   const description = nft.description || "−"
-  const image = nft.image || ""
   return (
     <>
       <div

--- a/examples/ethers/src/Nft.tsx
+++ b/examples/ethers/src/Nft.tsx
@@ -131,9 +131,9 @@ function NftDetails({ nft }: { nft?: NftMetadata }) {
     return null
   }
 
+  const { image, } = nft
   const name = nft.name || "Untitled"
   const description = nft.description || "−"
-  const image = nft.image || ""
   return (
     <>
       <div

--- a/examples/nfts.ts
+++ b/examples/nfts.ts
@@ -20,6 +20,7 @@ export default shuffle<[string, string, string, string]>([
     "https://market.decentraland.org/contracts/0x32b7495895264ac9d0b12d32afd435453458b1c6/tokens/4087",
   ],
 
+  // ERC-1155
   [
     "0xd07dc4262bcdbf85190c01c996b4c06a461d2430",
     "90473",
@@ -76,6 +77,7 @@ export default shuffle<[string, string, string, string]>([
     "https://niftygateway.com/itemdetail/secondary/0x1a9efe6d9a7a977a938f03b1a549bdd9cd316432/11000010006",
   ],
 
+  // ERC-1155
   [
     "0x495f947276749ce646f68ac8c248420045cb7b5e",
     "63990428236934811571513178702512145453357596655980286527887248477662016962561",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,15 @@
           "*.tsx"
         ],
         "rules": {
-          "import/no-default-export": "off"
+          "import/no-default-export": "off",
+          "import/no-unresolved": [
+            "error",
+            {
+              "ignore": [
+                "^react$"
+              ]
+            }
+          ]
         }
       }
     ]

--- a/src/fetchers/ethereum/index.tsx
+++ b/src/fetchers/ethereum/index.tsx
@@ -15,7 +15,7 @@ import {
 } from "../shared/decentraland-parcel"
 import { moonCatsMetadata, isMoonCats } from "../shared/mooncats"
 import { moonCatsCatId } from "./mooncats"
-import { fetchStandardNftUrl } from "./standard-nft"
+import { fetchStandardNftContractData } from "./standard-nft"
 
 export default function ethereumFetcher(
   config: EthereumFetcherConfig
@@ -50,9 +50,15 @@ export default function ethereumFetcher(
         return moonCatsMetadata(tokenId, moonCatsCatId(config))
       }
 
-      return fetchMetadata(
-        await fetchStandardNftUrl(contractAddress, tokenId, config)
+      const [metadataUrl, owner] = await fetchStandardNftContractData(
+        contractAddress,
+        tokenId,
+        config
       )
+
+      const metadata = await fetchMetadata(metadataUrl)
+
+      return { ...metadata, owner }
     },
   }
 }

--- a/src/fetchers/ethereum/utils.ts
+++ b/src/fetchers/ethereum/utils.ts
@@ -5,6 +5,7 @@ import type { EthereumProviderEip1193 } from "./types"
 // See https://docs.soliditylang.org/en/v0.5.3/abi-spec.html#function-selector-and-argument-encoding
 const URI_METHOD_ERC721 = "0xc87b56dd" // tokenURI(uint256)
 const URI_METHOD_ERC1155 = "0x0e89341c" // uri(uint256)
+const OWNER_OF_METHOD_ERC721 = "0x6352211e" // ownerOf(uint256)
 const SUPPORTS_INTERFACE_METHOD_ERC165 = "0x01ffc9a7" // supportsInterface(bytes4)
 
 // ERC165 identifiers
@@ -49,12 +50,29 @@ export function decodeString(hex: string): string {
   return new TextDecoder().decode(bytes)
 }
 
+export function decodeAddress(hex: string): string {
+  const data = hexToUint8Array(hex)
+  const bytes = data.subarray(0, 32)
+  const decoded = bytesToBigInt(bytes)
+  if (decoded >= BigInt(2) ** BigInt(160))
+    throw new Error(
+      `Encoded value is bigger than the largest possible address.  Decoded value: 0x${decoded.toString(
+        16
+      )}.`
+    )
+  return `0x${decoded.toString(16)}`
+}
+
 export function methodUriErc721(tokenId: bigint): string {
   return URI_METHOD_ERC721 + uint256Hex(tokenId)
 }
 
 export function methodUriErc1155(id: bigint): string {
   return URI_METHOD_ERC1155 + uint256Hex(id)
+}
+
+export function methodOwnerOfErc721(tokenId: bigint): string {
+  return OWNER_OF_METHOD_ERC721 + uint256Hex(tokenId)
 }
 
 export function supportsInterfaceMethodErc165(interfaceId: string): string {

--- a/src/fetchers/ethers/index.tsx
+++ b/src/fetchers/ethers/index.tsx
@@ -15,7 +15,7 @@ import {
 } from "../shared/decentraland-parcel"
 import { moonCatsMetadata, isMoonCats } from "../shared/mooncats"
 import { moonCatsCatId } from "./mooncats"
-import { fetchStandardNftUrl } from "./standard-nft"
+import { fetchStandardNftContractData } from "./standard-nft"
 
 export default function ethersFetcher(
   config: EthersFetcherConfig
@@ -50,9 +50,15 @@ export default function ethersFetcher(
         return moonCatsMetadata(tokenId, moonCatsCatId(config))
       }
 
-      return fetchMetadata(
-        await fetchStandardNftUrl(contractAddress, tokenId, config)
+      const [metadataUrl, owner] = await fetchStandardNftContractData(
+        contractAddress,
+        tokenId,
+        config
       )
+
+      const metadata = await fetchMetadata(metadataUrl)
+
+      return { ...metadata, owner }
     },
   }
 }

--- a/src/fetchers/ethers/standard-nft.tsx
+++ b/src/fetchers/ethers/standard-nft.tsx
@@ -7,31 +7,41 @@ import { normalizeTokenUrl, promiseAny } from "../../utils"
 const ABI = [
   // ERC-721
   "function tokenURI(uint256 _tokenId) external view returns (string)",
+  "function ownerOf(uint256 _tokenId) external view returns (address)",
   // ERC-1155
   "function uri(uint256 _id) external view returns (string)",
   // ERC-165
   "function supportsInterface(bytes4 interfaceID) external view returns (bool)",
 ]
 
-export async function fetchStandardNftUrl(
+type NftContract = InstanceType<typeof Contract> & {
+  ownerOf: ContractFunction<string>
+  supportsInterface: ContractFunction<boolean>
+  tokenURI: ContractFunction<string>
+  uri: ContractFunction<string>
+}
+
+async function url(contract: NftContract, tokenId: string): Promise<string> {
+  const uri = await promiseAny([
+    contract.uri(tokenId),
+    contract.tokenURI(tokenId),
+  ])
+  return normalizeTokenUrl(uri, tokenId)
+}
+
+export async function fetchStandardNftContractData(
   contractAddress: Address,
   tokenId: string,
   config: EthersFetcherConfig
-): Promise<string> {
+): Promise<[string, Address]> {
   const contract = new config.ethers.Contract(
     contractAddress,
     ABI,
     config.provider
-  ) as InstanceType<typeof Contract> & {
-    uri: ContractFunction<string>
-    tokenURI: ContractFunction<string>
-    supportsInterface: ContractFunction<boolean>
-  }
+  ) as NftContract
 
-  const url = await promiseAny([
-    contract.uri(tokenId),
-    contract.tokenURI(tokenId),
+  return Promise.all([
+    url(contract, tokenId),
+    contract.ownerOf(tokenId).catch(() => ""),
   ])
-
-  return normalizeTokenUrl(url, tokenId)
 }

--- a/src/fetchers/shared/cryptokitties.ts
+++ b/src/fetchers/shared/cryptokitties.ts
@@ -11,9 +11,10 @@ export async function cryptoKittiesMetadata(id: string): Promise<NftMetadata> {
     image_url: string
   }
   return {
-    name: data?.name ?? "Unknown",
     description: data?.bio ?? "−",
     image: data?.image_url ?? "",
+    name: data?.name ?? "Unknown",
+    owner: "",
   }
 }
 

--- a/src/fetchers/shared/cryptopunks.ts
+++ b/src/fetchers/shared/cryptopunks.ts
@@ -12,9 +12,10 @@ const CRYPTOPUNKS_DESCRIPTION = `
 
 export function cryptoPunksMetadata(index: string): NftMetadata {
   return {
-    name: `CryptoPunk ${index}`,
     description: CRYPTOPUNKS_DESCRIPTION,
     image: `https://www.larvalabs.com/cryptopunks/cryptopunk${index}.png`,
+    name: `CryptoPunk ${index}`,
+    owner: "",
   }
 }
 

--- a/src/fetchers/shared/decentraland-estate.tsx
+++ b/src/fetchers/shared/decentraland-estate.tsx
@@ -62,9 +62,10 @@ export async function decentralandEstateMetadata(
   const nft = data?.nfts?.[0]
 
   return {
-    name: nft?.name ?? "Unknown",
     description: nft?.estate?.data?.description ?? "−",
     image: nft?.image ?? "",
+    name: nft?.name ?? "Unknown",
+    owner: nft?.owner?.address ?? "",
   }
 }
 

--- a/src/fetchers/shared/decentraland-parcel.tsx
+++ b/src/fetchers/shared/decentraland-parcel.tsx
@@ -67,44 +67,13 @@ export async function decentralandParcelMetadata(
   const parcel = nft?.parcel
 
   return {
-    name: nft?.name ?? `Parcel ${parcel?.x},${parcel?.y}`,
     description: parcel?.data?.description ?? "−",
     image: nft?.image ?? "",
+    name: nft?.name ?? `Parcel ${parcel?.x},${parcel?.y}`,
+    owner: nft?.owner?.address ?? "",
   }
 }
 
 export function isDecentralandParcel(contractAddress: Address): boolean {
   return addressesEqual(contractAddress, DECENTRALAND_PARCEL)
 }
-
-// query NFTByTokenId($contractAddress: String, $tokenId: String) {
-//   nfts(
-//     where: { contractAddress: $contractAddress, tokenId: $tokenId }
-//     first: 1
-//   ) {
-//     id
-//     name
-//     image
-//     contractAddress
-//     tokenId
-//     category
-//     owner {
-//       address
-//     }
-//     parcel {
-//       x
-//       y
-//       data {
-//         description
-//       }
-//     }
-//     estate {
-//       size
-//       data {
-//         description
-//       }
-//     }
-//     ens {
-//       subdomain
-//     }
-//   }

--- a/src/fetchers/shared/fetch-metadata.tsx
+++ b/src/fetchers/shared/fetch-metadata.tsx
@@ -1,4 +1,4 @@
-import type { NftMetadata } from "../../types"
+import type { NftJsonMetadata } from "../../types"
 
 import {
   fixIncorrectImageField,
@@ -8,7 +8,7 @@ import {
   normalizeNftMetadata,
 } from "../../utils"
 
-export async function fetchMetadata(url: string): Promise<NftMetadata> {
+export async function fetchMetadata(url: string): Promise<NftJsonMetadata> {
   const res = await fetch(url)
 
   if (!res.ok) {

--- a/src/fetchers/shared/mooncats.ts
+++ b/src/fetchers/shared/mooncats.ts
@@ -48,6 +48,7 @@ export async function moonCatsMetadata(
       `The (unofficial) wrapped version of MoonCats Rescue. ` +
       `Original cat ID: ${catId}.`,
     image,
+    owner: "",
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,9 +30,16 @@ export type NftResultDone = {
 export type NftResult = NftResultLoading | NftResultError | NftResultDone
 
 export type NftMetadata = {
-  name: string
   description: string
   image: string
+  name: string
+  owner: Address
+}
+
+export type NftJsonMetadata = {
+  description: string
+  image: string
+  name: string
 }
 
 export type ContractMethod = {

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -1,4 +1,4 @@
-import type { Address, NftMetadata } from "./types"
+import type { Address, NftMetadata, NftJsonMetadata } from "./types"
 
 // Some NFT minting services misinterpreted the JSON schema from the EIP as
 // literal JSON, e.g. portion.io:
@@ -140,7 +140,7 @@ export function normalizeImageUrl(url: string): string {
   return ipfsUrl(url)
 }
 
-export function normalizeNftMetadata(data: NftMetadata): NftMetadata {
+export function normalizeNftMetadata(data: NftJsonMetadata): NftJsonMetadata {
   return {
     ...data,
     image: normalizeImageUrl(data.image),
@@ -192,7 +192,7 @@ export function isNftMetadataMixedInJsonSchema(
 
 export function fixNftMetadataMixedInJsonSchema(
   data: NftMetadataMixedInJsonSchema
-): NftMetadata {
+): NftJsonMetadata {
   return {
     name: data?.properties?.name?.description || "",
     description: data?.properties?.description?.description || "",

--- a/website/src/Nft.tsx
+++ b/website/src/Nft.tsx
@@ -131,9 +131,9 @@ function NftDetails({ nft }: { nft?: NftMetadata }) {
     return null
   }
 
+  const { image } = nft
   const name = nft.name || "Untitled"
   const description = nft.description || "−"
-  const image = nft.image || ""
   return (
     <>
       <div

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2362,14 +2362,14 @@ resolve@^1.19.0:
   languageName: node
   linkType: hard
 
-"swr@npm:^1.0.0-beta.5":
-  version: 1.0.0-beta.5
-  resolution: "swr@npm:1.0.0-beta.5"
+"swr@npm:^1.0.0-beta.6":
+  version: 1.0.0-beta.6
+  resolution: "swr@npm:1.0.0-beta.6"
   dependencies:
     dequal: 2.0.2
   peerDependencies:
     react: ^16.11.0 || ^17.0.0
-  checksum: c7a08be21d2a984997c41a02e275fe2fa5cbb809209d926e0e9d2e8c9e6848a9ddad569ee27b5b3a1dbe26f3bcd461ae01818903ca8d574d41912caaae41ced6
+  checksum: b67113b40001be62389195341b0eb7ad10fdcb4d724166228781ba22a99f26f1d2d0a9f2b2252f7bc8695e500376390b1e552b0e3581d8ba1e9328a580318cfc
   languageName: node
   linkType: hard
 
@@ -2472,7 +2472,7 @@ typescript@^4.2.3:
   version: 0.0.0-use.local
   resolution: "use-nft@portal:..::locator=use-nft-website%40workspace%3A."
   dependencies:
-    swr: ^1.0.0-beta.5
+    swr: ^1.0.0-beta.6
   peerDependencies:
     react: ">=17"
   languageName: node


### PR DESCRIPTION
Fixes #56.

It represents the current owner of the NFT.

Note that some NFT implementations don’t provide a `.ownerOf()` method, in which case `.owner` will return an empty string.